### PR TITLE
Registrar now supports refreshing multiple clients

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.0.2

--- a/src/main/scala/com/lightbend/registrar/net/ControlProtocolRoute.scala
+++ b/src/main/scala/com/lightbend/registrar/net/ControlProtocolRoute.scala
@@ -1,7 +1,6 @@
 package com.lightbend.registrar.net
 
 import akka.actor.ActorRef
-import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model.StatusCodes
 import akka.pattern.ask
 import akka.http.scaladsl.server._
@@ -28,16 +27,14 @@ object ControlProtocolRoute {
       (get & path(Segment)) { topic =>
         complete((registrationHandlerRef ? Inspect(topic)).mapTo[Seq[Record]])
       } ~
-      (post & path(Segment) & entity(as[String])) { case (topic, name) =>
+      (post & path(Segment / "register") & entity(as[String])) { case (topic, name) =>
         onSuccess((registrationHandlerRef ? Register(topic, name)).mapTo[Option[Record]]) {
           case None    => complete(StatusCodes.BadRequest)
           case Some(r) => complete(r)
         }
       } ~
-      (post & path(Segment / IntNumber / Segment)) { case (topic, id, name) =>
-        onSuccess((registrationHandlerRef ? Refresh(topic, id, name)).mapTo[Boolean]) { updated =>
-          complete(if (updated) StatusCodes.OK else StatusCodes.BadRequest)
-        }
+      (post & path(Segment / "refresh") & entity(as[Set[Registration]])) { case (topic, registrations) =>
+        complete((registrationHandlerRef ? Refresh(topic, registrations)).mapTo[RefreshResult])
       } ~
       (delete & path(Segment / IntNumber / Segment)) { case (topic, id, name) =>
         onSuccess((registrationHandlerRef ? Remove(topic, id, name)).mapTo[Boolean]) { deleted =>

--- a/src/main/scala/com/lightbend/registrar/net/JsonSupport.scala
+++ b/src/main/scala/com/lightbend/registrar/net/JsonSupport.scala
@@ -2,10 +2,12 @@ package com.lightbend.registrar.net
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import com.lightbend.registrar.RegistrationHandler
-import spray.json.DefaultJsonProtocol
+import spray.json.{ DefaultJsonProtocol, RootJsonFormat }
 
 object JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
   import RegistrationHandler._
 
-  implicit val recordFormat = jsonFormat4(Record.apply)
+  implicit val recordFormat: RootJsonFormat[Record] = jsonFormat4(Record.apply)
+  implicit val registrationFormat: RootJsonFormat[Registration] = jsonFormat2(Registration.apply)
+  implicit val refreshFormat: RootJsonFormat[RefreshResult] = jsonFormat2(RefreshResult.apply)
 }

--- a/src/test/scala/com/lightbend/registrar/net/JsonSupportSpec.scala
+++ b/src/test/scala/com/lightbend/registrar/net/JsonSupportSpec.scala
@@ -1,9 +1,8 @@
 package com.lightbend.registrar.net
 
-import com.lightbend.registrar.RegistrationHandler.Record
-import org.scalatest.{ Matchers, WordSpec }
+import com.lightbend.registrar.RegistrationHandler.{Record, RefreshResult, Registration}
+import org.scalatest.{Matchers, WordSpec}
 import spray.json._
-
 import JsonSupport._
 
 class JsonSupportSpec extends WordSpec
@@ -17,6 +16,14 @@ class JsonSupportSpec extends WordSpec
       assertThrows[IllegalArgumentException] {
         Record(3, null, Vector.empty, 10000L).toJson.compactPrint
       }
+    }
+
+    "Encode RefreshResult" in {
+      RefreshResult(Set(Registration(1, "one")), Set(Registration(2, "two"))).toJson.compactPrint shouldEqual """{"accepted":[{"id":1,"name":"one"}],"rejected":[{"id":2,"name":"two"}]}"""
+    }
+
+    "Encode Registration" in {
+      Registration(1, "one").toJson.compactPrint shouldEqual """{"id":1,"name":"one"}"""
     }
   }
 }


### PR DESCRIPTION
This PR adjusts the refresh format to allow multiple clients to be refreshed with a single message (thus http request). This support is required to implement the client logic.